### PR TITLE
separate flags for update-engine and locksmith

### DIFF
--- a/ignition/ignition_common.tf
+++ b/ignition/ignition_common.tf
@@ -7,12 +7,12 @@ data "ignition_filesystem" "root" {
 
 data "ignition_systemd_unit" "update-engine" {
   name = "update-engine.service"
-  mask = "${!var.enable_container_linux_updates}"
+  mask = "${!var.enable_container_linux_update-engine}"
 }
 
 data "ignition_systemd_unit" "locksmithd" {
   name = "locksmithd.service"
-  mask = "${!var.enable_container_linux_updates}"
+  mask = "${!var.enable_container_linux_locksmithd}"
 }
 
 data "ignition_file" "s3-iam-get" {

--- a/ignition/variables.tf
+++ b/ignition/variables.tf
@@ -1,6 +1,11 @@
-variable "enable_container_linux_updates" {
+variable "enable_container_linux_update-engine" {
   description = "Whether to enable automatic updates for Container Linux."
   default     = true
+}
+
+variable "enable_container_linux_locksmithd" {
+  description = "Whether to enable automatic updates for Container Linux."
+  default     = false
 }
 
 variable "etcd_image_url" {


### PR DESCRIPTION
allow independent masking of the units, new Container Linux update engine wants update-engine enabled and running and locksmithd masked