### PR TITLE
Use explicit self references in security group rules

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -102,12 +102,12 @@ resource "aws_security_group_rule" "egress-from-cfssl" {
 }
 
 resource "aws_security_group_rule" "ingress-cfssl-to-self" {
-  type                     = "ingress"
-  from_port                = 0
-  to_port                  = 0
-  protocol                 = "-1"
-  source_security_group_id = "${aws_security_group.cfssl.id}"
-  security_group_id        = "${aws_security_group.cfssl.id}"
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  security_group_id = "${aws_security_group.cfssl.id}"
+  self              = true
 }
 
 resource "aws_security_group_rule" "cfssl-ssh" {

--- a/etcd.tf
+++ b/etcd.tf
@@ -109,12 +109,12 @@ resource "aws_security_group_rule" "egress-from-etcd" {
 }
 
 resource "aws_security_group_rule" "ingress-etcd-to-self" {
-  type                     = "ingress"
-  from_port                = 0
-  to_port                  = 0
-  protocol                 = "-1"
-  source_security_group_id = "${aws_security_group.etcd.id}"
-  security_group_id        = "${aws_security_group.etcd.id}"
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  security_group_id = "${aws_security_group.etcd.id}"
+  self              = true
 }
 
 resource "aws_security_group_rule" "ingress-master-to-etcd" {

--- a/masters.tf
+++ b/masters.tf
@@ -150,12 +150,12 @@ resource "aws_security_group_rule" "egress-from-master" {
 }
 
 resource "aws_security_group_rule" "ingress-master-to-self" {
-  type                     = "ingress"
-  from_port                = 0
-  to_port                  = 0
-  protocol                 = "-1"
-  source_security_group_id = "${aws_security_group.master.id}"
-  security_group_id        = "${aws_security_group.master.id}"
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  security_group_id = "${aws_security_group.master.id}"
+  self              = true
 }
 
 resource "aws_security_group_rule" "ingress-elb-https-to-master" {

--- a/workers.tf
+++ b/workers.tf
@@ -171,12 +171,12 @@ resource "aws_security_group_rule" "egress-from-worker" {
 }
 
 resource "aws_security_group_rule" "ingress-worker-to-self" {
-  type                     = "ingress"
-  from_port                = 0
-  to_port                  = 0
-  protocol                 = "-1"
-  source_security_group_id = "${aws_security_group.worker.id}"
-  security_group_id        = "${aws_security_group.worker.id}"
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  security_group_id = "${aws_security_group.worker.id}"
+  self              = true
 }
 
 resource "aws_security_group_rule" "ingress-master-to-worker" {


### PR DESCRIPTION
Explicit self references is a nice way to avoid mistakes and showing intent.
https://www.terraform.io/docs/providers/aws/r/security_group_rule.html#self