### PR TITLE
hardcoding instance type

### DIFF
--- a/etcd.tf
+++ b/etcd.tf
@@ -85,7 +85,7 @@ resource "aws_ebs_volume" "etcd-data" {
 
 resource "aws_volume_attachment" "etcd-data" {
   count       = "${var.etcd_instance_count}"
-  device_name = "nvme6n1"
+  device_name = "/dev/nvme6n1"
   volume_id   = "${aws_ebs_volume.etcd-data.*.id[count.index]}"
   instance_id = "${aws_instance.etcd.*.id[count.index]}"
 }

--- a/etcd.tf
+++ b/etcd.tf
@@ -85,7 +85,7 @@ resource "aws_ebs_volume" "etcd-data" {
 
 resource "aws_volume_attachment" "etcd-data" {
   count       = "${var.etcd_instance_count}"
-  device_name = "/dev/nvme6"
+  device_name = "nvme6n1"
   volume_id   = "${aws_ebs_volume.etcd-data.*.id[count.index]}"
   instance_id = "${aws_instance.etcd.*.id[count.index]}"
 }

--- a/etcd.tf
+++ b/etcd.tf
@@ -85,7 +85,7 @@ resource "aws_ebs_volume" "etcd-data" {
 
 resource "aws_volume_attachment" "etcd-data" {
   count       = "${var.etcd_instance_count}"
-  device_name = "/dev/nvme1n1"
+  device_name = "/dev/nvme6"
   volume_id   = "${aws_ebs_volume.etcd-data.*.id[count.index]}"
   instance_id = "${aws_instance.etcd.*.id[count.index]}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -53,11 +53,6 @@ variable "etcd_instance_count" {
   description = "The number of etcd instances to launch."
 }
 
-variable "etcd_instance_type" {
-  default     = "t2.small"
-  description = "The type of etcd instances to launch."
-}
-
 variable "etcd_user_data" {
   description = "A list of the user data to provide to the etcd instances. Must be the same length as etcd_instance_count."
   type        = "list"


### PR DESCRIPTION
New instance type have a new device mapping. In order to not have to maintain a instance type/device map,
we are just going with a single instance type and a single device name.