### PR TITLE
Switch master ELB to NLB

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -7,7 +7,7 @@ output "cfssl_ip" {
 }
 
 output "master_address" {
-  value = "${aws_route53_record.master-elb.name}"
+  value = "${aws_route53_record.master-lb.name}"
 }
 
 output "etcd_security_group_id" {


### PR DESCRIPTION
Primarily to mitigate kubernetes issue with kubeletes losing connection
to masters ( ~06:20 in the morning for us ), and after a period ejecting
pods, until that connection is reistablished. Some of the related issues
and pull requests:

 - https://github.com/kubernetes/kubernetes/issues/41916
 - https://github.com/kubernetes/kubernetes/issues/48638
 - https://github.com/kubernetes/kubernetes/pull/52176

Using a NLB is a suggested mitigation from:
https://github.com/kubernetes/kubernetes/pull/52176#issuecomment-355143494

NLBs do not support security groups, so we delete the elb SG and open
443 to the world on the master security group