### PR TITLE
Additional input variables to calculate less stuff

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -1,11 +1,3 @@
-resource "null_resource" "cfssl_address" {
-  triggers {
-    subnet            = "${var.private_subnet_ids[0]}"
-    availability_zone = "${data.aws_subnet.private.*.availability_zone[0]}"
-    address           = "${cidrhost(data.aws_subnet.private.*.cidr_block[0], 5)}"
-  }
-}
-
 // IAM instance role
 resource "aws_iam_role" "cfssl" {
   name = "${var.cluster_name}_cfssl"
@@ -39,8 +31,8 @@ resource "aws_instance" "cfssl" {
   user_data              = "${var.cfssl_user_data}"
   key_name               = "${var.key_name}"
   vpc_security_group_ids = ["${aws_security_group.cfssl.id}"]
-  subnet_id              = "${null_resource.cfssl_address.triggers.subnet}"
-  private_ip             = "${null_resource.cfssl_address.triggers.address}"
+  subnet_id              = "${var.private_subnet_ids[0]}"
+  private_ip             = "${var.cfssl_server_address}"
 
   lifecycle {
     ignore_changes = ["ami"]
@@ -60,7 +52,7 @@ resource "aws_instance" "cfssl" {
 }
 
 resource "aws_ebs_volume" "cfssl-data" {
-  availability_zone = "${null_resource.cfssl_address.triggers.availability_zone}"
+  availability_zone = "${data.aws_subnet.private.*.availability_zone[0]}"
   size              = 5
   type              = "gp2"
 

--- a/common.tf
+++ b/common.tf
@@ -18,11 +18,11 @@ data "aws_vpc" "main" {
 }
 
 data "aws_subnet" "private" {
-  count = "${length(var.private_subnet_ids)}"
+  count = "${var.private_subnet_count}"
   id    = "${var.private_subnet_ids[count.index]}"
 }
 
 data "aws_subnet" "public" {
-  count = "${length(var.public_subnet_ids)}"
+  count = "${var.public_subnet_count}"
   id    = "${var.public_subnet_ids[count.index]}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,3 @@
-output "etcd_ip_list" {
-  value = ["${null_resource.etcd_address.*.triggers.address}"]
-}
-
-output "cfssl_ip" {
-  value = "${null_resource.cfssl_address.triggers.address}"
-}
-
 output "master_address" {
   value = "${aws_route53_record.master-lb.name}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,9 +11,17 @@ variable "vpc_id" {
   description = "The ID of the VPC to create resources in."
 }
 
+variable "public_subnet_count" {
+  description = "The number of public subnets"
+}
+
 variable "public_subnet_ids" {
   description = "A list of the available public subnets in which EC2 instances can be created."
   type        = "list"
+}
+
+variable "private_subnet_count" {
+  description = "The number of private subnets"
 }
 
 variable "private_subnet_ids" {
@@ -44,14 +52,22 @@ variable "route53_inaddr_arpa_zone_id" {
 }
 
 // cfssl server
+variable "cfssl_server_address" {
+  description = "The address of the cfssl server"
+}
+
 variable "cfssl_user_data" {
   description = "The user data to provide to the cfssl server."
 }
 
 // etcd nodes
 variable "etcd_instance_count" {
-  default     = "3"
   description = "The number of etcd instances to launch."
+}
+
+variable "etcd_addresses" {
+  description = "A list of ip adrresses for etcd instances"
+  type        = "list"
 }
 
 variable "etcd_instance_type" {


### PR DESCRIPTION
1. Add counts for subnets and remove default from etcd count
   to skip terraform errors when no resources are created
2. removed default etcd to make it a mandatory input
3. Get cfssl address as input and revome null_resource object
4. Make etcd_addresses an input and remove null_resource