### PR TITLE
Set termination policy to be OldestInstance

### DIFF
--- a/masters.tf
+++ b/masters.tf
@@ -80,6 +80,7 @@ resource "aws_autoscaling_group" "master" {
   vpc_zone_identifier       = ["${var.private_subnet_ids}"]
   target_group_arns         = ["${aws_lb_target_group.master443.arn}"]
   default_cooldown          = 60
+  termination_policies      = "OldestInstance"
 
   tags = [
     {

--- a/workers.tf
+++ b/workers.tf
@@ -94,6 +94,7 @@ resource "aws_autoscaling_group" "worker" {
   load_balancers            = ["${var.worker_elb_names}"]
   target_group_arns         = ["${var.worker_target_group_arns}"]
   default_cooldown          = 60
+  termination_policies      = "OldestInstance"
 
   tags = [
     {
@@ -128,6 +129,7 @@ resource "aws_autoscaling_group" "worker-spot" {
   load_balancers            = ["${var.worker_elb_names}"]
   target_group_arns         = ["${var.worker_target_group_arns}"]
   default_cooldown          = 60
+  termination_policies      = "OldestInstance"
 
   tags = [
     {


### PR DESCRIPTION
https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html#default-termination-policy
Plays well with using ASG capacity increate to upgrade instances