### PR TITLE
cfssl instance use m5 instance family

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -26,7 +26,7 @@ resource "aws_iam_instance_profile" "cfssl" {
 // EC2 Instance
 resource "aws_instance" "cfssl" {
   ami                    = "${var.containerlinux_ami_id}"
-  instance_type          = "t2.micro"
+  instance_type          = "m5.large"
   iam_instance_profile   = "${aws_iam_instance_profile.cfssl.name}"
   user_data              = "${var.cfssl_user_data}"
   key_name               = "${var.key_name}"
@@ -65,7 +65,11 @@ resource "aws_ebs_volume" "cfssl-data" {
 }
 
 resource "aws_volume_attachment" "cfssl-data" {
+  // This is a terraform workaround. The device_name is ignored by the
+  // instance, but terraform insists that it needs to be set. Actual device
+  // name will be something like: /dev/nvme1n1
   device_name = "/dev/xvdf"
+
   volume_id   = "${aws_ebs_volume.cfssl-data.*.id[count.index]}"
   instance_id = "${aws_instance.cfssl.*.id[count.index]}"
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,3 +13,7 @@ output "master_security_group_id" {
 output "worker_security_group_id" {
   value = "${aws_security_group.worker.id}"
 }
+
+output "cfssl_data_volumeid" {
+  value = "${join("", split("-", aws_ebs_volume.cfssl-data.id))}"
+}


### PR DESCRIPTION
Currently occasional cpu spike cause the t2 instance to go down and new
instances are unable to bootstrap (upgrades)

Until
terraform-providers/terraform-provider-aws#2927
becomes available, move all critical instances on non-metered cpu
instances types