### PR TITLE
sys: move to t3 instance family type

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -26,7 +26,7 @@ resource "aws_iam_instance_profile" "cfssl" {
 // EC2 Instance
 resource "aws_instance" "cfssl" {
   ami                    = "${var.containerlinux_ami_id}"
-  instance_type          = "t2.nano"
+  instance_type          = "t3.nano"
   iam_instance_profile   = "${aws_iam_instance_profile.cfssl.name}"
   user_data              = "${var.cfssl_user_data}"
   key_name               = "${var.key_name}"

--- a/etcd.tf
+++ b/etcd.tf
@@ -36,7 +36,10 @@ resource "aws_instance" "etcd" {
   private_ip             = "${var.etcd_addresses[count.index]}"
 
   lifecycle {
-    ignore_changes = ["ami"]
+    ignore_changes = [
+      "ami",
+      "credit_specification.0.cpu_credits",
+    ]
   }
 
   root_block_device = {

--- a/variables.tf
+++ b/variables.tf
@@ -76,7 +76,7 @@ variable "etcd_addresses" {
 }
 
 variable "etcd_instance_type" {
-  default     = "t2.small"
+  default     = "t3.small"
   description = "The type of etcd instances to launch."
 }
 
@@ -97,7 +97,7 @@ variable "master_instance_count" {
 }
 
 variable "master_instance_type" {
-  default     = "t2.small"
+  default     = "t3.small"
   description = "The type of kubernetes master instances to launch."
 }
 


### PR DESCRIPTION
Ignore the credit_specification, we can't optionally specify this (for
`m` type instances, and t3 helpfully defaults to unlimited), more
details:
https://github.com/terraform-providers/terraform-provider-aws/issues/5654