### PR TITLE
sys: add support for bounded roles

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -1,6 +1,8 @@
 // IAM instance role
 resource "aws_iam_role" "cfssl" {
-  name = "${var.cluster_name}_cfssl"
+  name                 = "${var.cluster_name}_cfssl"
+  path                 = "${var.iam_path}"
+  permissions_boundary = "${var.permissions_boundary}"
 
   assume_role_policy = <<EOS
 {
@@ -21,6 +23,7 @@ EOS
 resource "aws_iam_instance_profile" "cfssl" {
   name = "${var.cluster_name}-cfssl"
   role = "${aws_iam_role.cfssl.name}"
+  path = "${var.iam_path}"
 }
 
 // EC2 Instance

--- a/etcd.tf
+++ b/etcd.tf
@@ -1,6 +1,8 @@
 // IAM instance role
 resource "aws_iam_role" "etcd" {
-  name = "${var.cluster_name}_etcd"
+  name                 = "${var.cluster_name}_etcd"
+  path                 = "${var.iam_path}"
+  permissions_boundary = "${var.permissions_boundary}"
 
   assume_role_policy = <<EOS
 {
@@ -21,6 +23,7 @@ EOS
 resource "aws_iam_instance_profile" "etcd" {
   name = "${var.cluster_name}-etcd"
   role = "${aws_iam_role.etcd.name}"
+  path = "${var.iam_path}"
 }
 
 // EC2 Instances

--- a/masters.tf
+++ b/masters.tf
@@ -54,11 +54,13 @@ EOS
 // EC2 AutoScaling Group
 resource "aws_launch_configuration" "master" {
   iam_instance_profile = "${aws_iam_instance_profile.master.name}"
-  image_id             = "${var.containerlinux_ami_id}"
-  instance_type        = "${var.master_instance_type}"
-  key_name             = "${var.key_name}"
-  security_groups      = ["${aws_security_group.master.id}"]
-  user_data            = "${var.master_user_data}"
+
+  #image_id             = "${var.containerlinux_ami_id}"
+  image_id        = "ami-02d7f55d7813eca77"
+  instance_type   = "${var.master_instance_type}"
+  key_name        = "${var.key_name}"
+  security_groups = ["${aws_security_group.master.id}"]
+  user_data       = "${var.master_user_data}"
 
   lifecycle {
     create_before_destroy = true

--- a/masters.tf
+++ b/masters.tf
@@ -27,7 +27,6 @@ resource "aws_iam_instance_profile" "master" {
 resource "aws_iam_role_policy" "master" {
   name = "${var.cluster_name}_master"
   role = "${aws_iam_role.master.id}"
-  path = "${var.iam_path}"
 
   policy = <<EOS
 {

--- a/masters.tf
+++ b/masters.tf
@@ -1,6 +1,7 @@
 // IAM instance role
 resource "aws_iam_role" "master" {
   name = "${var.cluster_name}_master"
+  path = "${var.iam_path}"
 
   assume_role_policy = <<EOS
 {

--- a/masters.tf
+++ b/masters.tf
@@ -1,25 +1,8 @@
 // IAM instance role
 resource "aws_iam_role" "master" {
-  name = "${var.cluster_name}_master"
-
-  assume_role_policy = <<EOS
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": { "Service": "ec2.amazonaws.com" },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOS
-}
-
-resource "aws_iam_role" "master2" {
-  name                 = "${var.cluster_name}_master2"
+  name                 = "${var.cluster_name}_master"
   path                 = "${var.iam_path}"
-  permissions_boundary = "arn:aws:iam::${var.account_id}:policy/system/system-boundary"
+  permissions_boundary = "${var.permissions_boundary}"
 
   assume_role_policy = <<EOS
 {
@@ -38,44 +21,13 @@ EOS
 resource "aws_iam_instance_profile" "master" {
   name = "${var.cluster_name}-master"
   role = "${aws_iam_role.master.name}"
-}
-
-resource "aws_iam_instance_profile" "master2" {
-  name = "${var.cluster_name}-master2"
-  role = "${aws_iam_role.master2.name}"
   path = "${var.iam_path}"
 }
 
 resource "aws_iam_role_policy" "master" {
   name = "${var.cluster_name}_master"
   role = "${aws_iam_role.master.id}"
-
-  policy = <<EOS
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "ec2:*"
-      ],
-      "Effect": "Allow",
-      "Resource": [ "*" ]
-    },
-    {
-      "Action": [
-        "elasticloadbalancing:DescribeLoadBalancers"
-      ],
-      "Effect": "Allow",
-      "Resource": [ "*" ]
-    }
-  ]
-}
-EOS
-}
-
-resource "aws_iam_role_policy" "master2" {
-  name = "${var.cluster_name}_master2"
-  role = "${aws_iam_role.master2.id}"
+  path = "${var.iam_path}"
 
   policy = <<EOS
 {
@@ -103,25 +55,6 @@ EOS
 // EC2 AutoScaling Group
 resource "aws_launch_configuration" "master" {
   iam_instance_profile = "${aws_iam_instance_profile.master.name}"
-  image_id             = "${var.containerlinux_ami_id}"
-  instance_type        = "${var.master_instance_type}"
-  key_name             = "${var.key_name}"
-  security_groups      = ["${aws_security_group.master.id}"]
-  user_data            = "${var.master_user_data}"
-
-  lifecycle {
-    create_before_destroy = true
-  }
-
-  # Storage
-  root_block_device {
-    volume_type = "gp2"
-    volume_size = 50
-  }
-}
-
-resource "aws_launch_configuration" "master2" {
-  iam_instance_profile = "${aws_iam_instance_profile.master2.name}"
   image_id             = "${var.containerlinux_ami_id}"
   instance_type        = "${var.master_instance_type}"
   key_name             = "${var.key_name}"

--- a/masters.tf
+++ b/masters.tf
@@ -54,14 +54,11 @@ EOS
 // EC2 AutoScaling Group
 resource "aws_launch_configuration" "master" {
   iam_instance_profile = "${aws_iam_instance_profile.master.name}"
-
-  image_id = "${var.containerlinux_ami_id}"
-
-  #image_id        = "ami-02d7f55d7813eca77"
-  instance_type   = "${var.master_instance_type}"
-  key_name        = "${var.key_name}"
-  security_groups = ["${aws_security_group.master.id}"]
-  user_data       = "${var.master_user_data}"
+  image_id             = "${var.containerlinux_ami_id}"
+  instance_type        = "${var.master_instance_type}"
+  key_name             = "${var.key_name}"
+  security_groups      = ["${aws_security_group.master.id}"]
+  user_data            = "${var.master_user_data}"
 
   lifecycle {
     create_before_destroy = true

--- a/masters.tf
+++ b/masters.tf
@@ -55,8 +55,9 @@ EOS
 resource "aws_launch_configuration" "master" {
   iam_instance_profile = "${aws_iam_instance_profile.master.name}"
 
-  #image_id             = "${var.containerlinux_ami_id}"
-  image_id        = "ami-02d7f55d7813eca77"
+  image_id = "${var.containerlinux_ami_id}"
+
+  #image_id        = "ami-02d7f55d7813eca77"
   instance_type   = "${var.master_instance_type}"
   key_name        = "${var.key_name}"
   security_groups = ["${aws_security_group.master.id}"]

--- a/masters.tf
+++ b/masters.tf
@@ -17,8 +17,9 @@ EOS
 }
 
 resource "aws_iam_role" "master2" {
-  name = "${var.cluster_name}_master2"
-  path = "${var.iam_path}"
+  name                 = "${var.cluster_name}_master2"
+  path                 = "${var.iam_path}"
+  permissions_boundary = "arn:aws:iam::${var.account_id}:policy/system/system-boundary"
 
   assume_role_policy = <<EOS
 {

--- a/masters.tf
+++ b/masters.tf
@@ -102,6 +102,25 @@ EOS
 
 // EC2 AutoScaling Group
 resource "aws_launch_configuration" "master" {
+  iam_instance_profile = "${aws_iam_instance_profile.master.name}"
+  image_id             = "${var.containerlinux_ami_id}"
+  instance_type        = "${var.master_instance_type}"
+  key_name             = "${var.key_name}"
+  security_groups      = ["${aws_security_group.master.id}"]
+  user_data            = "${var.master_user_data}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  # Storage
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = 50
+  }
+}
+
+resource "aws_launch_configuration" "master2" {
   iam_instance_profile = "${aws_iam_instance_profile.master2.name}"
   image_id             = "${var.containerlinux_ami_id}"
   instance_type        = "${var.master_instance_type}"

--- a/variables.tf
+++ b/variables.tf
@@ -56,8 +56,9 @@ variable "iam_path" {
   default     = "/system/"
 }
 
-variable "account_id" {
-  description = "AWS account id where the resources should be created"
+variable "permission_boundary" {
+  description = "permission_boudnary to apply to iam resources"
+  default     = ""
 }
 
 // cfssl server

--- a/variables.tf
+++ b/variables.tf
@@ -53,7 +53,7 @@ variable "route53_inaddr_arpa_zone_id" {
 
 variable "iam_path" {
   description = "path where iam resources should be created"
-  default     = "/system/"
+  default     = "/"
 }
 
 variable "permissions_boundary" {

--- a/variables.tf
+++ b/variables.tf
@@ -56,7 +56,7 @@ variable "iam_path" {
   default     = "/system/"
 }
 
-variable "permission_boundary" {
+variable "permissions_boundary" {
   description = "permission_boudnary to apply to iam resources"
   default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -56,6 +56,10 @@ variable "iam_path" {
   default     = "/system/"
 }
 
+variable "account_id" {
+  description = "AWS account id where the resources should be created"
+}
+
 // cfssl server
 variable "cfssl_server_address" {
   description = "The address of the cfssl server"

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,11 @@ variable "route53_inaddr_arpa_zone_id" {
   description = "The ID of the Route53 Zone to add pointer records to."
 }
 
+variable "iam_path" {
+  description = "path where iam resources should be created"
+  default     = "/system/"
+}
+
 // cfssl server
 variable "cfssl_server_address" {
   description = "The address of the cfssl server"

--- a/workers.tf
+++ b/workers.tf
@@ -1,6 +1,8 @@
 // IAM instance role
 resource "aws_iam_role" "worker" {
-  name = "${var.cluster_name}_worker"
+  name                 = "${var.cluster_name}_worker"
+  path                 = "${var.iam_path}"
+  permissions_boundary = "${var.permissions_boundary}"
 
   assume_role_policy = <<EOS
 {
@@ -21,6 +23,7 @@ EOS
 resource "aws_iam_instance_profile" "worker" {
   name = "${var.cluster_name}-worker"
   role = "${aws_iam_role.worker.name}"
+  path = "${var.iam_path}"
 }
 
 resource "aws_iam_role_policy" "worker" {
@@ -46,18 +49,16 @@ EOS
 // EC2 AutoScaling groups
 resource "aws_launch_configuration" "worker" {
   iam_instance_profile = "${aws_iam_instance_profile.worker.name}"
+  image_id             = "${var.containerlinux_ami_id}"
+  instance_type        = "${var.worker_instance_type}"
+  key_name             = "${var.key_name}"
+  security_groups      = ["${aws_security_group.worker.id}"]
+  user_data            = "${var.worker_user_data}"
 
-  image_id = "${var.containerlinux_ami_id}"
-
-  #image_id = "ami-02d7f55d7813eca77"
-
-  instance_type   = "${var.worker_instance_type}"
-  key_name        = "${var.key_name}"
-  security_groups = ["${aws_security_group.worker.id}"]
-  user_data       = "${var.worker_user_data}"
   lifecycle {
     create_before_destroy = true
   }
+
   root_block_device {
     volume_size = 50
     volume_type = "gp2"
@@ -66,15 +67,12 @@ resource "aws_launch_configuration" "worker" {
 
 resource "aws_launch_configuration" "worker-spot" {
   iam_instance_profile = "${aws_iam_instance_profile.worker.name}"
-
-  image_id = "${var.containerlinux_ami_id}"
-
-  #image_id        = "ami-02d7f55d7813eca77"
-  instance_type   = "${var.worker_instance_type}"
-  spot_price      = "${var.worker_spot_instance_bid}"
-  key_name        = "${var.key_name}"
-  security_groups = ["${aws_security_group.worker.id}"]
-  user_data       = "${var.worker_user_data}"
+  image_id             = "${var.containerlinux_ami_id}"
+  instance_type        = "${var.worker_instance_type}"
+  spot_price           = "${var.worker_spot_instance_bid}"
+  key_name             = "${var.key_name}"
+  security_groups      = ["${aws_security_group.worker.id}"]
+  user_data            = "${var.worker_user_data}"
 
   lifecycle {
     create_before_destroy = true

--- a/workers.tf
+++ b/workers.tf
@@ -47,18 +47,17 @@ EOS
 resource "aws_launch_configuration" "worker" {
   iam_instance_profile = "${aws_iam_instance_profile.worker.name}"
 
-  #image_id             = "${var.containerlinux_ami_id}"
-  image_id = "ami-02d7f55d7813eca77"
+  image_id = "${var.containerlinux_ami_id}"
+
+  #image_id = "ami-02d7f55d7813eca77"
 
   instance_type   = "${var.worker_instance_type}"
   key_name        = "${var.key_name}"
   security_groups = ["${aws_security_group.worker.id}"]
   user_data       = "${var.worker_user_data}"
-
   lifecycle {
     create_before_destroy = true
   }
-
   root_block_device {
     volume_size = 50
     volume_type = "gp2"
@@ -68,8 +67,9 @@ resource "aws_launch_configuration" "worker" {
 resource "aws_launch_configuration" "worker-spot" {
   iam_instance_profile = "${aws_iam_instance_profile.worker.name}"
 
-  #image_id             = "${var.containerlinux_ami_id}"
-  image_id        = "ami-02d7f55d7813eca77"
+  image_id = "${var.containerlinux_ami_id}"
+
+  #image_id        = "ami-02d7f55d7813eca77"
   instance_type   = "${var.worker_instance_type}"
   spot_price      = "${var.worker_spot_instance_bid}"
   key_name        = "${var.key_name}"

--- a/workers.tf
+++ b/workers.tf
@@ -46,11 +46,14 @@ EOS
 // EC2 AutoScaling groups
 resource "aws_launch_configuration" "worker" {
   iam_instance_profile = "${aws_iam_instance_profile.worker.name}"
-  image_id             = "${var.containerlinux_ami_id}"
-  instance_type        = "${var.worker_instance_type}"
-  key_name             = "${var.key_name}"
-  security_groups      = ["${aws_security_group.worker.id}"]
-  user_data            = "${var.worker_user_data}"
+
+  #image_id             = "${var.containerlinux_ami_id}"
+  image_id = "ami-02d7f55d7813eca77"
+
+  instance_type   = "${var.worker_instance_type}"
+  key_name        = "${var.key_name}"
+  security_groups = ["${aws_security_group.worker.id}"]
+  user_data       = "${var.worker_user_data}"
 
   lifecycle {
     create_before_destroy = true
@@ -64,12 +67,14 @@ resource "aws_launch_configuration" "worker" {
 
 resource "aws_launch_configuration" "worker-spot" {
   iam_instance_profile = "${aws_iam_instance_profile.worker.name}"
-  image_id             = "${var.containerlinux_ami_id}"
-  instance_type        = "${var.worker_instance_type}"
-  spot_price           = "${var.worker_spot_instance_bid}"
-  key_name             = "${var.key_name}"
-  security_groups      = ["${aws_security_group.worker.id}"]
-  user_data            = "${var.worker_user_data}"
+
+  #image_id             = "${var.containerlinux_ami_id}"
+  image_id        = "ami-02d7f55d7813eca77"
+  instance_type   = "${var.worker_instance_type}"
+  spot_price      = "${var.worker_spot_instance_bid}"
+  key_name        = "${var.key_name}"
+  security_groups = ["${aws_security_group.worker.id}"]
+  user_data       = "${var.worker_user_data}"
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
* Backwards compatible, no-op with new defaults
* Needs `org-admin` first time that new path/boundaries are provided