### PR TITLE
increase root volume size to get more iops/allow more burst

### DIFF
--- a/masters.tf
+++ b/masters.tf
@@ -67,7 +67,7 @@ resource "aws_launch_configuration" "master" {
   # Storage
   root_block_device {
     volume_type = "gp2"
-    volume_size = 50
+    volume_size = 100
   }
 }
 

--- a/workers.tf
+++ b/workers.tf
@@ -60,7 +60,7 @@ resource "aws_launch_configuration" "worker" {
   }
 
   root_block_device {
-    volume_size = 50
+    volume_size = 100
     volume_type = "gp2"
   }
 }
@@ -79,7 +79,7 @@ resource "aws_launch_configuration" "worker-spot" {
   }
 
   root_block_device {
-    volume_size = 50
+    volume_size = 100
     volume_type = "gp2"
   }
 }


### PR DESCRIPTION
Reduce the chance of applications using local disk of imapcting node and
core components running on the same node