### PR TITLE
remove SnapshotManager related tags from etcd volumes

### DIFF
--- a/etcd.tf
+++ b/etcd.tf
@@ -66,8 +66,6 @@ resource "aws_ebs_volume" "etcd-data" {
     "Name", "etcd ${var.cluster_name} data vol ${count.index}",
     "terraform.io/component", "${var.cluster_name}/etcd/${count.index}",
     "kubernetes.io/cluster/${var.cluster_name}", "owned",
-    "SnapshotManager", "true",
-    "SnapshotRetentionDays", "3",
   )}"
 }
 


### PR DESCRIPTION
We don't need these tags now that snapshot-manager is gone.