### PR TITLE
sys: allow empty list of LBs for worker template

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -155,11 +155,13 @@ variable "worker_user_data" {
 }
 
 variable "worker_elb_names" {
+  default     = []
   description = "A list of Classic ELB names to be attached to the worker autoscaling groups."
   type        = list(string)
 }
 
 variable "worker_target_group_arns" {
+  default     = []
   description = "A list of ALB Target Group ARNs to register the worker instances with."
   type        = list(string)
 }


### PR DESCRIPTION
Should be optional