### PR TITLE
Add permission to manage load balancers to master

### DIFF
--- a/masters.tf
+++ b/masters.tf
@@ -57,8 +57,11 @@ data "aws_iam_policy_document" "master" {
   }
 
   statement {
+    # https://docs.aws.amazon.com/IAM/latest/UserGuide/list_elasticloadbalancing.html
     actions = [
-      "elasticloadbalancing:DescribeLoadBalancers"
+      "elasticloadbalancing:DescribeLoadBalancers",
+      "elasticloadbalancing:CreateLoadBalancer"
+      "elasticloadbalancing:DeleteLoadBalancer"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
Necessary for the knative experiment in exp-aws-1.
See https://github.com/utilitywarehouse/kubernetes-manifests/pull/23034
for more information