### PR TITLE
Revert "Merge pull request #49 from utilitywarehouse/csi-driver"

### DIFF
--- a/workers.tf
+++ b/workers.tf
@@ -56,28 +56,6 @@ data "aws_iam_policy_document" "worker" {
     resources = ["*"]
   }
 
-  # https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/example-iam-policy.json
-  statement {
-    actions = [
-      "ec2:AttachVolume",
-      "ec2:CreateSnapshot",
-      "ec2:CreateTags",
-      "ec2:CreateVolume",
-      "ec2:DeleteSnapshot",
-      "ec2:DeleteTags",
-      "ec2:DeleteVolume",
-      "ec2:DescribeAvailabilityZones",
-      "ec2:DescribeInstances", ## dup
-      "ec2:DescribeSnapshots",
-      "ec2:DescribeTags",
-      "ec2:DescribeVolumes",
-      "ec2:DescribeVolumesModifications",
-      "ec2:DetachVolume",
-      "ec2:ModifyVolume",
-    ]
-    resources = ["*"]
-  }
-
   statement {
     actions   = ["s3:GetObject"]
     resources = ["arn:aws:s3:::${aws_s3_bucket.userdata.id}/worker-*"]


### PR DESCRIPTION
This reverts commit d1898d02e6128d057c259179551cfc956b29b14f, reversing
changes made to b365791b7a51efa0e9e0fa6c7464f22fcdcd54ea.

This change would grant all pods running on workers permission to act on
EBS volumes, for example delete them.

This is better handled as an access key pair passed directly to
controller that needs these permissions.