### PR TITLE
Update config to be compatible with v4.2.0 provider

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -29,12 +29,14 @@ data "aws_subnet" "public" {
 
 resource "aws_s3_bucket" "userdata" {
   bucket = "${var.bucket_prefix}-ignition-userdata-${var.cluster_name}"
+}
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
+resource "aws_s3_bucket_server_side_encryption_configuration" "userdata" {
+  bucket = aws_s3_bucket.userdata.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
     }
   }
 }

--- a/masters.tf
+++ b/masters.tf
@@ -16,7 +16,7 @@ data "template_file" "master" {
 EOF
 }
 
-resource "aws_s3_bucket_object" "master" {
+resource "aws_s3_object" "master" {
   bucket  = aws_s3_bucket.userdata.id
   key     = "master-config-${sha1(var.master_user_data)}.json"
   content = var.master_user_data
@@ -123,29 +123,30 @@ resource "aws_autoscaling_group" "master" {
   target_group_arns         = [aws_lb_target_group.master443.arn]
   default_cooldown          = 60
 
-  tags = [
-    {
-      key                 = "Name"
-      value               = "master ${var.cluster_name}"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "terraform.io/component"
-      value               = "${var.cluster_name}/master"
-      propagate_at_launch = true
-    },
-    {
-      // kube uses this tag to learn its cluster name and tag managed resources
-      key                 = "kubernetes.io/cluster/${var.cluster_name}"
-      value               = "owned"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "owner"
-      value               = "system"
-      propagate_at_launch = true
-    },
-  ]
+  tag {
+    key                 = "Name"
+    value               = "master ${var.cluster_name}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "terraform.io/component"
+    value               = "${var.cluster_name}/master"
+    propagate_at_launch = true
+  }
+
+  tag {
+    // kube uses this tag to learn its cluster name and tag managed resources
+    key                 = "kubernetes.io/cluster/${var.cluster_name}"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "owner"
+    value               = "system"
+    propagate_at_launch = true
+  }
 }
 
 resource "aws_lb" "master" {

--- a/workers.tf
+++ b/workers.tf
@@ -16,7 +16,7 @@ data "template_file" "worker" {
 EOF
 }
 
-resource "aws_s3_bucket_object" "worker" {
+resource "aws_s3_object" "worker" {
   bucket  = aws_s3_bucket.userdata.id
   key     = "worker-config-${sha1(var.worker_user_data)}.json"
   content = var.worker_user_data
@@ -120,29 +120,30 @@ resource "aws_autoscaling_group" "worker" {
   target_group_arns         = var.worker_target_group_arns
   default_cooldown          = 60
 
-  tags = [
-    {
-      key                 = "Name"
-      value               = "worker ${var.cluster_name}"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "terraform.io/component"
-      value               = "${var.cluster_name}/worker"
-      propagate_at_launch = true
-    },
-    {
-      // kube uses this tag to learn its cluster name and tag managed resources
-      key                 = "kubernetes.io/cluster/${var.cluster_name}"
-      value               = "owned"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "owner"
-      value               = "system"
-      propagate_at_launch = true
-    },
-  ]
+  tag {
+    key                 = "Name"
+    value               = "worker ${var.cluster_name}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "terraform.io/component"
+    value               = "${var.cluster_name}/worker"
+    propagate_at_launch = true
+  }
+
+  tag {
+    // kube uses this tag to learn its cluster name and tag managed resources
+    key                 = "kubernetes.io/cluster/${var.cluster_name}"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "owner"
+    value               = "system"
+    propagate_at_launch = true
+  }
 }
 
 resource "aws_autoscaling_group" "worker-spot" {
@@ -159,29 +160,30 @@ resource "aws_autoscaling_group" "worker-spot" {
   target_group_arns         = var.worker_target_group_arns
   default_cooldown          = 60
 
-  tags = [
-    {
-      key                 = "Name"
-      value               = "worker-spot ${var.cluster_name}"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "terraform.io/component"
-      value               = "${var.cluster_name}/worker-spot"
-      propagate_at_launch = true
-    },
-    {
-      // kube uses this tag to learn its cluster name and tag managed resources
-      key                 = "kubernetes.io/cluster/${var.cluster_name}"
-      value               = "owned"
-      propagate_at_launch = true
-    },
-    {
-      key                 = "owner"
-      value               = "system"
-      propagate_at_launch = true
-    },
-  ]
+  tag {
+    key                 = "Name"
+    value               = "worker-spot ${var.cluster_name}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "terraform.io/component"
+    value               = "${var.cluster_name}/worker-spot"
+    propagate_at_launch = true
+  }
+
+  tag {
+    // kube uses this tag to learn its cluster name and tag managed resources
+    key                 = "kubernetes.io/cluster/${var.cluster_name}"
+    value               = "owned"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "owner"
+    value               = "system"
+    propagate_at_launch = true
+  }
 }
 
 // VPC security groups


### PR DESCRIPTION
user_data attribute is no longer "in-place" change, followed by a
stop/start of the instance. This breaks our flow for cfssl and etcd
instances - as ignition will only run on the first boot.  Subsequent
changes and reboot of the instance will ignore new ignition config.

As a workaround I'm moving user_data attribute to be set by
launch_template. Changing launch_template as part of the instance will
cause resource replace:
https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/instance.go#L320

And changing the name of the launch_template also causes resource
replace:
https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/ec2/launch_template.go#L41

So if we include the sha1sum of the userdata string in launch_template
name - it will force our instance to be replaced. This works with
current version of the provider but can obviously change.

Other changes:

- "tags" list is deprecated in favour of individual "tag" blocks.
- "aws_s3_bucket_object" deprecated in favour of "aws_s3_object"
- s3 bucket "server_side_encryption_configuration" is no longer
  attribute block, but its own resource
