### PR TITLE
Ignore user_data changes on the instance

### DIFF
--- a/userdata.tftpl
+++ b/userdata.tftpl
@@ -1,0 +1,13 @@
+{
+  "ignition": {
+    "version": "2.2.0",
+    "config": {
+      "replace": {
+        "source": "${source}",
+        "aws": {
+          "region": "${region}"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
user_data no longer handled by the instance resource, and instead set by
launch_template. However Terraform shows changes to the user_data
attribute on the instance. Perhaps related:
https://github.com/hashicorp/terraform-provider-aws/issues/5011. Since
we don't care about it, we just ignore changes to user_data on instance.

Remove deprecated template_file resources and replace with templatefile
func. Also actually use a single template for all user_data.

Remove obvious comments.
