### PR TITLE
Move to aws_launch_template from aws_launch_configuration

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -141,11 +141,6 @@ variable "worker_spot_instance_count" {
   description = "The number of kubernetes worker spot instances to launch."
 }
 
-variable "worker_spot_instance_bid" {
-  description = "The price to bid for kubernetes worker spot instances."
-  default     = ""
-}
-
 variable "worker_instance_type" {
   default     = "m5.large"
   description = "The type of kubernetes worker instances to launch."


### PR DESCRIPTION
AWS is decomissioning launch configurations:
https://aws.amazon.com/blogs/compute/amazon-ec2-auto-scaling-will-no-longer-add-support-for-new-ec2-features-to-launch-configurations/

They have a timeline for when they disallow creation of new launch
templates, while this might not affect us soon, it makes sense to run a
supported resource if we need to provision anew in a new account.

Also remove the spot price bid variable, not used.
