### PR TITLE
Remove hash suffix from masters and worker s3 location

### DIFF
--- a/masters.tf
+++ b/masters.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_object" "master" {
   bucket  = aws_s3_bucket.userdata.id
-  key     = "master-config-${sha1(var.master_user_data)}.json"
+  key     = "master-config.json"
   content = var.master_user_data
 }
 
@@ -96,7 +96,7 @@ resource "aws_launch_template" "master" {
     templatefile("${path.module}/userdata.tftpl",
       {
         region = var.region,
-        source = "s3://${aws_s3_bucket.userdata.id}/master-config-${sha1(var.master_user_data)}.json"
+        source = "s3://${aws_s3_bucket.userdata.id}/master-config.json"
       }
     )
   )

--- a/workers.tf
+++ b/workers.tf
@@ -1,6 +1,6 @@
 resource "aws_s3_object" "worker" {
   bucket  = aws_s3_bucket.userdata.id
-  key     = "worker-config-${sha1(var.worker_user_data)}.json"
+  key     = "worker-config.json"
   content = var.worker_user_data
 }
 
@@ -74,7 +74,7 @@ resource "aws_launch_template" "worker" {
     templatefile("${path.module}/userdata.tftpl",
       {
         region = var.region,
-        source = "s3://${aws_s3_bucket.userdata.id}/worker-config-${sha1(var.worker_user_data)}.json"
+        source = "s3://${aws_s3_bucket.userdata.id}/worker-config.json"
       }
     )
   )
@@ -113,7 +113,7 @@ resource "aws_launch_template" "worker_spot" {
     templatefile("${path.module}/userdata.tftpl",
       {
         region = var.region,
-        source = "s3://${aws_s3_bucket.userdata.id}/worker-config-${sha1(var.worker_user_data)}.json"
+        source = "s3://${aws_s3_bucket.userdata.id}/worker-config.json"
       }
     )
   )


### PR DESCRIPTION
Use a static location to store ignition under s3 for master and worker nodes. This will mean that the launch_templates will not update on ignition changes, but nodes will be able to fetch ignition updates on reboots (if first_boot flag is set). The goal is to be able to use an operator like kured in order to perform rolling updates.