### PR TITLE
Increase cfssl root volume to 15GB

### DIFF
--- a/cfssl.tf
+++ b/cfssl.tf
@@ -66,7 +66,7 @@ resource "aws_instance" "cfssl" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = 5
+    volume_size = 15
   }
 
   credit_specification {


### PR DESCRIPTION
Due to the following error:
> Error: creating EC2 Instance: operation error EC2: RunInstances, https response error StatusCode: 400, RequestID: 0baeb8d9-0539-4d26-87a2-80a067b254e0, api error InvalidBlockDeviceMapping: Volume of size 5GB is smaller than snapshot 'snap-0dcf48830af5bfde2', expect size>= 13GB
