### PR TITLE
Increase etcd root volume to 15GB

### DIFF
--- a/etcd.tf
+++ b/etcd.tf
@@ -68,7 +68,7 @@ resource "aws_instance" "etcd" {
 
   root_block_device {
     volume_type = "gp2"
-    volume_size = 10
+    volume_size = 15
   }
 
   // kube uses the kubernetes.io tag to learn its cluster name and tag managed resources


### PR DESCRIPTION
> │ Error: creating EC2 Instance: operation error EC2: RunInstances, https response error StatusCode: 400, RequestID: 5d045635-e75b-4e56-83f3-a2f1752de8ca, api error InvalidBlockDeviceMapping: Volume of size 10GB is smaller than snapshot 'snap-0dcf48830af5bfde2', expect size>= 13GB
